### PR TITLE
Tenancy context

### DIFF
--- a/Packages/DotNET/Tenancy/Source/AspNetCore/HttpContextExtensions.cs
+++ b/Packages/DotNET/Tenancy/Source/AspNetCore/HttpContextExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) woksin-org. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.AspNetCore.Http;
+using Woksin.Extensions.Tenancy.Context;
+
+namespace Woksin.Extensions.Tenancy.AspNetCore;
+
+/// <summary>
+/// Extension methods for getting <see cref="ITenantContext"/> from the <see cref="HttpContext"/>.
+/// </summary>
+public static class HttpContextExtensions
+{
+    public static ITenantContext<TTenant> GetTenantContext<TTenant>(this HttpContext context)
+        where TTenant : class, ITenantInfo, new()
+    {
+        ITenantContext<TTenant> result = TenantContext<TTenant>.Unresolved();
+        if (context.Items.TryGetValue(TenancyMiddleware.TenantContextItemKey, out var tenantContext) && tenantContext is not null)
+        {
+            result = tenantContext as ITenantContext<TTenant> ?? throw new InvalidCastException($"Could not cast tenant context of type {tenantContext.GetType()} to {typeof(ITenantContext<TTenant>)}");
+        }
+        return result;
+    }
+    
+    public static ITenantContext GetTenantContext(this HttpContext context)
+    {
+        ITenantContext result = TenantContext.Unresolved();
+        if (context.Items.TryGetValue(TenancyMiddleware.TenantContextItemKey, out var tenantContext) && tenantContext is not null)
+        {
+            result = tenantContext as ITenantContext ?? throw new InvalidCastException($"Could not cast tenant context of type {tenantContext.GetType()} to {typeof(ITenantContext)}");
+        }
+        return result;
+    }
+
+    public static ITenantContext GetTenantContext(this HttpRequest request) => request.HttpContext.GetTenantContext();
+    public static ITenantContext<TTenant> GetTenantContext<TTenant>(this HttpRequest request) 
+        where TTenant : class, ITenantInfo, new() => request.HttpContext.GetTenantContext<TTenant>();
+
+}

--- a/Packages/DotNET/Tenancy/Source/Base/Context/ITenantContextAccessor.cs
+++ b/Packages/DotNET/Tenancy/Source/Base/Context/ITenantContextAccessor.cs
@@ -14,6 +14,33 @@ public interface ITenantContextAccessor<TTenant>
     /// Gets the current <see cref="ITenantContext"/>.
     /// </summary>
     ITenantContext<TTenant> CurrentTenant { get; set; }
+    
+    /// <summary>
+    /// Throws an exception if the AsyncLocal tenant context is disabled. 
+    /// </summary>
+    /// <param name="accessor">The registered <see cref="ITenantContextAccessor"/>.</param>
+    /// <param name="tenancyOptions">The configured <see cref="TenancyOptions{TTenant}"/>.</param>
+    /// <exception cref="InvalidOperationException">The exception that is thrown.</exception>
+    public static void ThrowIfDisabledTenantContext(ITenantContextAccessor accessor, TenancyOptions<TTenant> tenancyOptions)
+    {
+        if (accessor is StaticTenantContextAccessor<TTenant> && !tenancyOptions.IsUsingStaticTenant(out _))
+        {
+            throw new InvalidOperationException("Current tenant context cannot be resolved when AsyncLocal Tenant Context is disabled");
+        }
+    }
+    /// <summary>
+    /// Throws an exception if the AsyncLocal tenant context is disabled. 
+    /// </summary>
+    /// <param name="accessor">The registered <see cref="ITenantContextAccessor"/>.</param>
+    /// <param name="tenancyOptions">The configured <see cref="TenancyOptions{TTenant}"/>.</param>
+    /// <exception cref="InvalidOperationException">The exception that is thrown.</exception>
+    public static void ThrowIfDisabledTenantContext(ITenantContextAccessor<TTenant> accessor, TenancyOptions<TTenant> tenancyOptions)
+    {
+        if (accessor is StaticTenantContextAccessor<TTenant> && !tenancyOptions.IsUsingStaticTenant(out _))
+        {
+            throw new InvalidOperationException("Current tenant context cannot be resolved when AsyncLocal Tenant Context is disabled");
+        }
+    }
 }
 
 /// <summary>

--- a/Packages/DotNET/Tenancy/Source/Base/Context/StaticTenantContextAccessor.cs
+++ b/Packages/DotNET/Tenancy/Source/Base/Context/StaticTenantContextAccessor.cs
@@ -1,0 +1,61 @@
+// Copyright (c) woksin-org. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Woksin.Extensions.Tenancy.Context;
+
+/// <summary>
+/// Represents static implementation of <see cref="ITenantContextAccessor{TTenant}"/> and <see cref="ITenantContextAccessor"/> that will be in use if AsyncLocal tenant context is disabled.
+/// </summary>
+/// <remarks>Unless <see cref="TenancyOptions{TTenant}.StaticTenantId"/> is configured this implementation will always return the 'unresolved' <see cref="ITenantContext"/>.</remarks>
+/// <typeparam name="TTenant">The <see cref="Type"/> of the <see cref="ITenantInfo"/>.</typeparam>
+public partial class StaticTenantContextAccessor<TTenant> : ITenantContextAccessor<TTenant>, ITenantContextAccessor
+    where TTenant : class, ITenantInfo, new()
+{
+    readonly IOptionsMonitor<TenancyOptions<TTenant>> _options;
+    readonly ILogger<StaticTenantContextAccessor<TTenant>> _logger;
+
+    public StaticTenantContextAccessor(IOptionsMonitor<TenancyOptions<TTenant>> options, ILogger<StaticTenantContextAccessor<TTenant>> logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public ITenantContext<TTenant> CurrentTenant
+    {
+        get
+        {
+            if (_options.CurrentValue.IsUsingStaticTenant(out var staticTenantId))
+            {
+                return TenantContext<TTenant>.Static(new TTenant
+                {
+                    Id = staticTenantId
+                });
+            }
+            LogReturningUnresolvedContext(_logger);
+            return TenantContext<TTenant>.Unresolved();
+        }
+
+        // ReSharper disable once ValueParameterNotUsed
+        set
+        {
+            LogCannotSetContext(_logger);
+        }
+    }
+
+    /// <inheritdoc />
+    ITenantContext ITenantContextAccessor.CurrentTenant
+    {
+        get => CurrentTenant as ITenantContext ?? TenantContext<TTenant>.Unresolved();
+        set => CurrentTenant = value as ITenantContext<TTenant> ?? throw new ArgumentNullException(nameof(value));
+    }
+
+    [LoggerMessage(LogLevel.Warning, "When tenant context is disabled it is not possible to set the tenant context")]
+    static partial void LogCannotSetContext(ILogger logger);
+    
+    [LoggerMessage(LogLevel.Warning, "When tenant context is disabled and static tenant is not configured the tenant context will always be unresolved")]
+    static partial void LogReturningUnresolvedContext(ILogger logger);
+}

--- a/Packages/DotNET/Tenancy/Source/Base/Context/TenantContextAccessor.cs
+++ b/Packages/DotNET/Tenancy/Source/Base/Context/TenantContextAccessor.cs
@@ -26,9 +26,10 @@ public class TenantContextAccessor<TTenant> : ITenantContextAccessor<TTenant>, I
     {
         get
         {
+            // This is simply a minor performance optimization to avoid accessing the AsyncLocal when not necessary. 
             if (_options.CurrentValue.IsUsingStaticTenant(out var staticTenantId))
             {
-                return TenantContext<TTenant>.Static(new TTenant()
+                return TenantContext<TTenant>.Static(new TTenant
                 {
                     Id = staticTenantId
                 });


### PR DESCRIPTION
## Summary

Added more features that makes it easier to use this package together with third party libraries and frameworks like Wolverine, Akka, etc.

### Added

- Add resolved tenant context to the `HttpContext.Item` dictionary and a way to easily retrieve it from the `HttpContext` without relying on the `AsyncLocal` `TenantContextAccessor`
- `StaticTenantContextAccessor` that resolves either the statically configured tenant or the 'unresolved' tenant context. This type will be used instead of the `AsyncLocal` `TenantContextAccessor` if `DisableAsyncLocalTenantContext` method on `TenancyBuilder`. This can be useful if you're only interested in using the tenant context by passing it around in messages or using the one that's added to the `HttpContext`. For instance using frameworks and libraries that relies on running different processes on different threads or resuming contexts (Actor frameworks, Wolverine, etc.) then it can be useful to not rely on the `AsyncLocal` `TenantContextAccessor`