### PR TITLE
Tenant Options

### DIFF
--- a/Packages/DotNET/Configurations/Source/Tenancy/Configurations.Tenancy.csproj
+++ b/Packages/DotNET/Configurations/Source/Tenancy/Configurations.Tenancy.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
         <PackageReference Include="Microsoft.Extensions.Options" />
         
-        <PackageReference Include="Woksin.Extensions.Tenancy" VersionOverride="1.0.1"/>
+        <PackageReference Include="Woksin.Extensions.Tenancy" VersionOverride="1.1.0"/>
     </ItemGroup>
     
     <ItemGroup>

--- a/Packages/DotNET/Configurations/Source/Tenancy/ITenantOptions.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/ITenantOptions.cs
@@ -1,0 +1,120 @@
+// Copyright (c) woksin-org. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Woksin.Extensions.Tenancy;
+using Woksin.Extensions.Tenancy.Context;
+
+namespace Woksin.Extensions.Configurations.Tenancy;
+
+/// <summary>
+/// Represents a system for getting options for tenant configurations without relying on the <see cref="TenantContextAccessor{TTenant}"/>.
+/// </summary>
+public interface ITenantOptions
+{
+    public IOptions<TOptions> OptionsFor<TOptions>(string tenantId)
+        where TOptions : class, new();
+    public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(string tenantId)
+        where TOptions : class, new();
+    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(string tenantId)
+        where TOptions : class, new();
+}
+
+/// <summary>
+/// Represents a system for getting options for tenant configurations without relying on the <see cref="TenantContextAccessor{TTenant}"/>.
+/// </summary>
+/// <typeparam name="TTenant">The <see cref="Type"/> of <see cref="ITenantInfo"/>.</typeparam>
+public interface ITenantOptions<TTenant>
+    where TTenant : class, ITenantInfo, new()
+{
+    public IOptions<TOptions> OptionsFor<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class, new();
+    public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class, new();
+    
+    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class, new();
+}
+
+/// <summary>
+/// Represents an implementation of <see cref="ITenantOptions{TTenant}"/> keeping an internal state of the <see cref="IOptions{TOptions}"/>;
+/// </summary>
+/// <typeparam name="TTenant"></typeparam>
+public class TenantOptions<TTenant> : ITenantOptions<TTenant>, ITenantOptions
+    where TTenant : class, ITenantInfo, new()
+{
+    readonly IOptionsMonitor<TenancyOptions<TTenant>> _options;
+    readonly IServiceProvider _serviceProvider;
+    readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object>> _optionsPerTenantPerType = new();
+    readonly ConcurrentDictionary<Type, ConcurrentDictionary<string, object>> _optionsMonitorsPerTenantPerType = new();
+
+    public TenantOptions(IOptionsMonitor<TenancyOptions<TTenant>> options, IServiceProvider serviceProvider)
+    {
+        _options = options;
+        _serviceProvider = serviceProvider;
+    }
+    
+    public IOptions<TOptions> OptionsFor<TOptions>(string tenantId)
+        where TOptions : class, new()
+    {
+        _options.CurrentValue.TryGetTenantContext(tenantId, out var tenantContext);
+        return OptionsFor<TOptions>(tenantContext);
+    }
+
+    public IOptions<TOptions> OptionsFor<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class, new()
+    {
+        ThrowIfTenantNotResolved<TOptions>(tenant, out var tenantInfo);
+        var optionsPerTenant = _optionsPerTenantPerType.GetOrAdd(typeof(TOptions), new ConcurrentDictionary<string, object>());
+        return (IOptions<TOptions>)optionsPerTenant.GetOrAdd(tenantInfo.Id, _ => CreateTenantOptionsManager<TOptions>(tenant));
+    }
+
+    public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(string tenantId)
+        where TOptions : class, new()
+    {
+        _options.CurrentValue.TryGetTenantContext(tenantId, out var tenantContext);
+        return OptionsSnapshotFor<TOptions>(tenantContext);
+    }
+
+    public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class, new()
+    {
+        ThrowIfTenantNotResolved<TOptions>(tenant, out _);
+        return CreateTenantOptionsManager<TOptions>(tenant);
+    }
+
+    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(string tenantId) where TOptions : class, new()
+    {
+        _options.CurrentValue.TryGetTenantContext(tenantId, out var tenantContext);
+        return OptionsMonitorFor<TOptions>(tenantContext);
+    }
+
+    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(ITenantContext<TTenant> tenant) where TOptions : class, new()
+    {
+        ThrowIfTenantNotResolved<TOptions>(tenant, out var tenantInfo);
+        var optionsMonitorsPerTenant = _optionsMonitorsPerTenantPerType.GetOrAdd(typeof(TOptions), new ConcurrentDictionary<string, object>());
+        return (IOptionsMonitor<TOptions>)optionsMonitorsPerTenant.GetOrAdd(tenantInfo.Id, _ => new OptionsMonitor<TOptions>(
+            CreateOptionsFactory<TOptions>(tenant),
+            _serviceProvider.GetRequiredService<IEnumerable<IOptionsChangeTokenSource<TOptions>>>(),
+            new OptionsCache<TOptions>()));
+    }
+
+    StaticTenantOptionsFactory<TOptions, TTenant> CreateOptionsFactory<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class, new() =>
+        ActivatorUtilities.CreateInstance<StaticTenantOptionsFactory<TOptions, TTenant>>(_serviceProvider, tenant);
+
+    TenantOptionsManager<TOptions> CreateTenantOptionsManager<TOptions>(ITenantContext<TTenant> tenant) where TOptions : class, new()
+        => new(CreateOptionsFactory<TOptions>(tenant), new OptionsCache<TOptions>());
+    
+    void ThrowIfTenantNotResolved<TOptions>(ITenantContext<TTenant> tenant, [NotNull]out TTenant tenantInfo)
+        where TOptions : class, new()
+    {
+        if (!tenant.Resolved(out tenantInfo!, out _))
+        {
+            throw new CannotResolveTenantConfigurationWhenTenantContextIsNotResolved(typeof(TOptions));
+        }
+    }
+}

--- a/Packages/DotNET/Configurations/Source/Tenancy/TenantConfigurationBuilder.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/TenantConfigurationBuilder.cs
@@ -27,6 +27,8 @@ public class TenantConfigurationBuilder<TTenant> : BaseConfigurationBuilder<Tena
         : base(services, configurationPrefixes)
     {
         _tenancyBuilder = Services.AddTenancyExtension<TTenant>();
+        Services.TryAddSingleton<ITenantOptions<TTenant>, TenantOptions<TTenant>>();
+        Services.TryAddSingleton<ITenantOptions>(sp => (ITenantOptions)sp.GetRequiredService<ITenantOptions<TTenant>>());
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Follows the theme of the previous PR #30 and `Woksin.Extensions.Tenancy` 1.1.0 that added functionality to not rely on `AsyncLocal` tenant context

### Added

- `ITenantOptions` that can resolve instances of `IOptions`, `IOptionsSnapshot` and `IOptionsMonitor` for tenant configurations. This is very useful when you don't want to be relying on the `AsyncLocal` tenant context and instead want to resolve tenant options manually.