### PR TITLE
Remove new() constrain from tenant options classes

### DIFF
--- a/Packages/DotNET/Configurations/Source/Core/ConfigurationObjectDefinition.cs
+++ b/Packages/DotNET/Configurations/Source/Core/ConfigurationObjectDefinition.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 
 namespace Woksin.Extensions.Configurations;
 

--- a/Packages/DotNET/Configurations/Source/Tenancy/ConfigureTenantOptions.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/ConfigureTenantOptions.cs
@@ -12,7 +12,7 @@ namespace Woksin.Extensions.Configurations.Tenancy;
 /// <typeparam name="TTenant">The <see cref="Type"/> of the <see cref="ITenantInfo"/>.</typeparam>
 /// <param name="configureOptions">Callback to configure <typeparamref name="TOptions"/></param>
 public class ConfigureTenantOptions<TOptions, TTenant>(Action<TOptions, TTenant> configureOptions) : IConfigureTenantOptions<TOptions, TTenant>
-    where TOptions : class, new()
+    where TOptions : class
     where TTenant : class, ITenantInfo, new()
 {
     /// <inheritdoc />

--- a/Packages/DotNET/Configurations/Source/Tenancy/IConfigureTenantOptions.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/IConfigureTenantOptions.cs
@@ -11,7 +11,7 @@ namespace Woksin.Extensions.Configurations.Tenancy;
 /// <typeparam name="TOptions">Options type being configured.</typeparam>
 /// <typeparam name="TTenant">A type implementing ITenantInfo.</typeparam>
 public interface IConfigureTenantOptions<in TOptions, in TTenant>
-    where TOptions : class, new()
+    where TOptions : class
     where TTenant : class, ITenantInfo, new()
 {
     /// <summary>

--- a/Packages/DotNET/Configurations/Source/Tenancy/ITenantOptions.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/ITenantOptions.cs
@@ -16,11 +16,11 @@ namespace Woksin.Extensions.Configurations.Tenancy;
 public interface ITenantOptions
 {
     public IOptions<TOptions> OptionsFor<TOptions>(string tenantId)
-        where TOptions : class, new();
+        where TOptions : class;
     public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(string tenantId)
-        where TOptions : class, new();
+        where TOptions : class;
     public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(string tenantId)
-        where TOptions : class, new();
+        where TOptions : class;
 }
 
 /// <summary>
@@ -31,12 +31,12 @@ public interface ITenantOptions<TTenant>
     where TTenant : class, ITenantInfo, new()
 {
     public IOptions<TOptions> OptionsFor<TOptions>(ITenantContext<TTenant> tenant)
-        where TOptions : class, new();
+        where TOptions : class;
     public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(ITenantContext<TTenant> tenant)
-        where TOptions : class, new();
+        where TOptions : class;
     
     public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(ITenantContext<TTenant> tenant)
-        where TOptions : class, new();
+        where TOptions : class;
 }
 
 /// <summary>
@@ -58,14 +58,14 @@ public class TenantOptions<TTenant> : ITenantOptions<TTenant>, ITenantOptions
     }
     
     public IOptions<TOptions> OptionsFor<TOptions>(string tenantId)
-        where TOptions : class, new()
+        where TOptions : class
     {
         _options.CurrentValue.TryGetTenantContext(tenantId, out var tenantContext);
         return OptionsFor<TOptions>(tenantContext);
     }
 
     public IOptions<TOptions> OptionsFor<TOptions>(ITenantContext<TTenant> tenant)
-        where TOptions : class, new()
+        where TOptions : class
     {
         ThrowIfTenantNotResolved<TOptions>(tenant, out var tenantInfo);
         var optionsPerTenant = _optionsPerTenantPerType.GetOrAdd(typeof(TOptions), new ConcurrentDictionary<string, object>());
@@ -73,26 +73,28 @@ public class TenantOptions<TTenant> : ITenantOptions<TTenant>, ITenantOptions
     }
 
     public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(string tenantId)
-        where TOptions : class, new()
+        where TOptions : class
     {
         _options.CurrentValue.TryGetTenantContext(tenantId, out var tenantContext);
         return OptionsSnapshotFor<TOptions>(tenantContext);
     }
 
     public IOptionsSnapshot<TOptions> OptionsSnapshotFor<TOptions>(ITenantContext<TTenant> tenant)
-        where TOptions : class, new()
+        where TOptions : class
     {
         ThrowIfTenantNotResolved<TOptions>(tenant, out _);
         return CreateTenantOptionsManager<TOptions>(tenant);
     }
 
-    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(string tenantId) where TOptions : class, new()
+    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(string tenantId)
+        where TOptions : class
     {
         _options.CurrentValue.TryGetTenantContext(tenantId, out var tenantContext);
         return OptionsMonitorFor<TOptions>(tenantContext);
     }
 
-    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(ITenantContext<TTenant> tenant) where TOptions : class, new()
+    public IOptionsMonitor<TOptions> OptionsMonitorFor<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class
     {
         ThrowIfTenantNotResolved<TOptions>(tenant, out var tenantInfo);
         var optionsMonitorsPerTenant = _optionsMonitorsPerTenantPerType.GetOrAdd(typeof(TOptions), new ConcurrentDictionary<string, object>());
@@ -103,14 +105,15 @@ public class TenantOptions<TTenant> : ITenantOptions<TTenant>, ITenantOptions
     }
 
     StaticTenantOptionsFactory<TOptions, TTenant> CreateOptionsFactory<TOptions>(ITenantContext<TTenant> tenant)
-        where TOptions : class, new() =>
+        where TOptions : class =>
         ActivatorUtilities.CreateInstance<StaticTenantOptionsFactory<TOptions, TTenant>>(_serviceProvider, tenant);
 
-    TenantOptionsManager<TOptions> CreateTenantOptionsManager<TOptions>(ITenantContext<TTenant> tenant) where TOptions : class, new()
+    TenantOptionsManager<TOptions> CreateTenantOptionsManager<TOptions>(ITenantContext<TTenant> tenant)
+        where TOptions : class
         => new(CreateOptionsFactory<TOptions>(tenant), new OptionsCache<TOptions>());
     
     void ThrowIfTenantNotResolved<TOptions>(ITenantContext<TTenant> tenant, [NotNull]out TTenant tenantInfo)
-        where TOptions : class, new()
+        where TOptions : class
     {
         if (!tenant.Resolved(out tenantInfo!, out _))
         {

--- a/Packages/DotNET/Configurations/Source/Tenancy/TenantConfigurationBuilder.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/TenantConfigurationBuilder.cs
@@ -106,7 +106,7 @@ public class TenantConfigurationBuilder<TTenant> : BaseConfigurationBuilder<Tena
     /// <typeparam name="TOption">The <see cref="Type"/> of the options to configure.</typeparam>
     /// <returns>The builder for continuation.</returns>
     public TenantConfigurationBuilder<TTenant> Configure<TOption>(Action<TOption, TTenant> configure)
-        where TOption : class, new()
+        where TOption : class
     {
         Services.AddSingleton<IConfigureTenantOptions<TOption, TTenant>>(new ConfigureTenantOptions<TOption, TTenant>(configure));
         return this;

--- a/Packages/DotNET/Configurations/Source/Tenancy/TenantOptionsFactory.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/TenantOptionsFactory.cs
@@ -14,7 +14,7 @@ namespace Woksin.Extensions.Configurations.Tenancy;
 /// <typeparam name="TOptions">The type of options being requested.</typeparam>
 /// <typeparam name="TTenant">The type of the tenant info.</typeparam>
 public class TenantOptionsFactory<TOptions, TTenant> : BaseTenantOptionsFactory<TOptions, TTenant>
-    where TOptions : class, new()
+    where TOptions : class
     where TTenant : class, ITenantInfo, new()
 {
     readonly ITenantContextAccessor<TTenant> _multiTenantContextAccessor;
@@ -42,7 +42,7 @@ public class TenantOptionsFactory<TOptions, TTenant> : BaseTenantOptionsFactory<
 /// <typeparam name="TOptions">The type of options being requested.</typeparam>
 /// <typeparam name="TTenant">The type of the tenant info.</typeparam>
 public class StaticTenantOptionsFactory<TOptions, TTenant> : BaseTenantOptionsFactory<TOptions, TTenant>
-    where TOptions : class, new()
+    where TOptions : class
     where TTenant : class, ITenantInfo, new()
 {
     readonly ITenantContext<TTenant> _tenantContext;
@@ -65,7 +65,7 @@ public class StaticTenantOptionsFactory<TOptions, TTenant> : BaseTenantOptionsFa
 }
 
 public abstract class BaseTenantOptionsFactory<TOptions, TTenant> : ConfigurationsExtensionOptionsFactory<TOptions>
-    where TOptions : class, new()
+    where TOptions : class
     where TTenant : class, ITenantInfo, new()
 {
     readonly IEnumerable<IConfigureTenantOptions<TOptions, TTenant>> _configureTenantOptions;

--- a/Packages/DotNET/Configurations/Source/Tenancy/TenantOptionsManager.cs
+++ b/Packages/DotNET/Configurations/Source/Tenancy/TenantOptionsManager.cs
@@ -9,7 +9,7 @@ namespace Woksin.Extensions.Configurations.Tenancy;
 /// Implementation of IOptions and IOptionsSnapshot that uses dependency injection for its private cache.
 /// </summary>
 /// <typeparam name="TOptions">The type of options being configured.</typeparam>
-public class TenantOptionsManager<TOptions> : IOptionsSnapshot<TOptions> where TOptions : class, new()
+public class TenantOptionsManager<TOptions> : IOptionsSnapshot<TOptions> where TOptions : class
 {
     readonly IOptionsFactory<TOptions> _factory;
     readonly IOptionsMonitorCache<TOptions> _cache;


### PR DESCRIPTION
## Summary

### Fixed

- Removes unnecessarily strict `new()` restriction on generic type parameter for tenant options types
